### PR TITLE
Add offboard_from_project support

### DIFF
--- a/app/controllers/offboardings_controller.rb
+++ b/app/controllers/offboardings_controller.rb
@@ -7,4 +7,10 @@ class OffboardingsController < ApplicationController
 
     redirect_to admin_users_path
   end
+
+  def update
+    user = User.find(params['id'])
+    user.offboard_from_project!
+    redirect_to admin_user_path(user)
+  end
 end

--- a/app/models/action_log.rb
+++ b/app/models/action_log.rb
@@ -1,4 +1,4 @@
 class ActionLog < ApplicationRecord
   enum status: { success: 'success', warning: 'warning', error: 'error' }
-  enum action: { onboard: 'onboard', offboard: 'offboard' }
+  enum action: { onboard: 'onboard', offboard: 'offboard', offboard_from_project: 'offboard_from_project' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: { case_sensitive: false }
   validates :email, email: true
   validates :github, uniqueness: { case_sensitive: false, allow_nil: true }
-  validates :project_id, presence: true
+  validates :project_id, presence: true, on: :create
 
   def full_name = "#{first_name} #{last_name}"
 
@@ -30,6 +30,11 @@ class User < ApplicationRecord
     update!(offboarded_at: Time.now)
   end
 
+  def offboard_from_project!
+    process_services_for(:offboard_from_project)
+    update!(project_id: nil)
+  end
+
   private
 
   def process_services_for(action_name)
@@ -41,15 +46,18 @@ class User < ApplicationRecord
       setting_plus_common = setting.json_value.merge(common_settings[setting.service_key])
       handler = Services[setting.service_key]
 
-      begin
-        result = handler.send(action_name, member: user, configuration: setting_plus_common) || NULL_RESULT
-
+      unless handler.respond_to?(action_name)
         ActionLog.create!(user: user.email, project: setting.project_key, service: setting.service_key,
-                          action: action_name, status: result.status, note: result.note)
-      rescue StandardError => e
-        ActionLog.create!(user: user.email, project: setting.project_key, service: setting.service_key,
-                          action: action_name, status: :error, note: e.message)
+                          action: action_name, status: :warning, note: "#{action_name} method not defined for #{setting.service_key} handler")
+        next
       end
+
+      result = handler.send(action_name, member: user, configuration: setting_plus_common) || NULL_RESULT
+      ActionLog.create!(user: user.email, project: setting.project_key, service: setting.service_key,
+                        action: action_name, status: result.status, note: result.note)
+    rescue StandardError => e
+      ActionLog.create!(user: user.email, project: setting.project_key, service: setting.service_key,
+                        action: action_name, status: :error, note: e.message)
     end
   end
 end

--- a/app/services/github/github.rb
+++ b/app/services/github/github.rb
@@ -91,7 +91,8 @@ module Github
       end
     end
 
-    def offboard_from_project(member:, project:)
+    def offboard_from_project(member:, configuration:)
+      project = configuration['team']
       teams = team_configuration(project).slice('standard_team', 'admin_team')
       teams.each_value do |team_name|
         team = find_team(team_name)
@@ -99,7 +100,7 @@ module Github
                                                 member.github) && @client.remove_team_membership(team.id,
                                                                                                  member.github)
 
-        puts "OK: #{member.github} was succesfully removed from team #{team.name}"
+        Result.new(:success, "OK: #{member.github} was succesfully removed from team #{team.name}")
       end
     end
 

--- a/app/services/google_group/google.rb
+++ b/app/services/google_group/google.rb
@@ -90,16 +90,15 @@ module GoogleGroup
       Result.new(:warning, "Error: There are not groups. Can't remove #{member.email}")
     end
 
-    def offboard_from_project(member:, project:)
-      configuration = team_configuration(project)
+    def offboard_from_project(member:, configuration:)
       configuration.values.each do |group_name|
         next unless group = find_group(group_name)
 
         if @client.has_group_membership(group.id, member.email)
           if @client.remove_group_membership(group.id, member.email)
-            puts "OK: #{member.email} was succesfully removed from group #{group.name}"
+            return Result.new(:success, "OK: #{member.email} was succesfully removed from group #{group.name}")
           else
-            puts "Error: Can't remove #{member.email} from group #{group.name}"
+            return Result.new(:error, "Error: Can't remove #{member.email} from group #{group.name}")
           end
         end
       end

--- a/app/services/heroku/heroku.rb
+++ b/app/services/heroku/heroku.rb
@@ -39,11 +39,12 @@ module Heroku
     def offboard_from_project(member:, configuration:)
       if team = @client.find_team_by_name(configuration['team']) && @client.find_membership(team, member.email)
         if @client.team_member.delete(team['id'], member.email)
-          puts "OK: #{member.email} was succesfully removed from team #{team['name']}"
+          Result.new(:success, "#{member.email} was succesfully removed from team #{team['name']}")
         else
-          puts "Error: Can't remove #{member.email} from team #{team['name']}"
+          Result.new(:error, "Error: Can't remove #{member.email} from team #{team['name']}")
         end
       end
+      Result.new(:warning, "#{member.email} is not member of any team in Heroku")
     end
 
     def start(project:)

--- a/app/services/null_service/null_service.rb
+++ b/app/services/null_service/null_service.rb
@@ -10,6 +10,8 @@ module NullService
 
     def offboard(member:, configuration:) = result
 
+    def offboard_from_project(member:, configuration:) = result
+
     def result = Result.new(:warning, "There is not handler for #{@service} in Able Gate")
   end
 end

--- a/app/services/pivotal_tracker/pivotal_tracker.rb
+++ b/app/services/pivotal_tracker/pivotal_tracker.rb
@@ -40,13 +40,13 @@ module PivotalTracker
       end
     end
 
-    def offboard_from_project(member:, project:)
-      configuration = team_configuration(project)
+    def offboard_from_project(member:, configuration:)
       project_name = configuration['project']
       account = @client.find_account_by_id(@account)
       if project = @client.find_project_by_name(project_name) && project_membership = @client.find_membership(project,
                                                                                                               member.email) && project.delete_membership(project_membership.id)
-        puts "OK: #{member.email} was succesfully removed from project #{project.name} in Pivotal Tracker"
+        Result.new(:success,
+                   "OK: #{member.email} was succesfully removed from project #{project.name} in Pivotal Tracker")
       end
     end
 

--- a/app/services/sentry/sentry.rb
+++ b/app/services/sentry/sentry.rb
@@ -28,21 +28,19 @@ module Sentry
       end
     end
 
-    def offboard_from_project(member:, project:)
-      team = if configuration = team_configuration(project)
-               @client.find_team(configuration['team'])
-             else
-               @client.find_team(project)
-             end
+    def offboard_from_project(member:, configuration:)
+      project = configuration['team']
+      team =  @client.find_team(project)
       if team
         if @client.find_member(member.email)
           @client.remove_membership(member.email, team['slug'])
-          puts "OK: #{member.email} was removed from the #{team['slug']} team in Sentry"
+          Result.new(:success, "OK: #{member.email} was removed from the #{team['slug']} team in Sentry")
         else
-          puts "Warning: #{member.email} is not a member of the organization in Sentry"
+          Result.new(:warning, "Warning: #{member.email} is not a member of the organization in Sentry")
         end
       else
-        puts "Error: The team #{project} doesn't have a valid Sentry team. Please verify your configuration.\n"
+        Result.new(:error,
+                   "Error: The team #{project} doesn't have a valid Sentry team. Please verify your configuration.")
       end
     end
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,58 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: page.resource.class.human_attribute_name(attribute.name),
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>">
+          <% if attribute.data && attribute.name == "project" %>
+            <%= attribute.data.name.titleize %> 
+            (<%= link_to offboarding_path(project_id: page.resource.project_id), method: :put, data: { confirm: "Are you sure you want to do this?" } do %>  
+              Offboard from project
+            <% end %>)
+          <% else %>
+            <%= render_field attribute, page: page %>
+          <% end %>
+      </dd>
+
+    <% end %>
+  </dl>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
 
   resources :onboardings, only: %i[create]
-  resources :offboardings, only: %i[create]
+  resources :offboardings, only: %i[create update]
 
   root 'home#index'
   delete 'logout', to: 'sessions#destroy'

--- a/db/migrate/20210421042343_add_offboard_from_project_to_action_log_action.rb
+++ b/db/migrate/20210421042343_add_offboard_from_project_to_action_log_action.rb
@@ -1,0 +1,19 @@
+class AddOffboardFromProjectToActionLogAction < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE action_logs ALTER COLUMN action TYPE VARCHAR(255);
+      DROP TYPE action_log_action;
+      CREATE TYPE action_log_action AS ENUM ('onboard', 'offboard', 'offboard_from_project');
+      ALTER TABLE action_logs ALTER COLUMN action TYPE action_log_action USING (action::action_log_action);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE action_logs ALTER COLUMN action TYPE VARCHAR(255);
+      DROP TYPE action_log_action;
+      CREATE TYPE action_log_action AS ENUM ('onboard', 'offboard');
+      ALTER TABLE action_logs ALTER COLUMN action TYPE action_log_action USING (action::action_log_action);
+    SQL
+  end
+ end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_19_215241) do
+ActiveRecord::Schema.define(version: 2021_04_21_042343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
- This implementation adds support to offboarding from a project
- The following services are enabled to offboarding from a project: 
```
heroku, pivotal, sentry, github, and google
```
closes https://fino.able.co/products/69/projects/1664